### PR TITLE
Retain - Change supported physical address type from BUSINESS to WORK.

### DIFF
--- a/retain-spec/openapi.json
+++ b/retain-spec/openapi.json
@@ -430,9 +430,9 @@
             "type": "string",
             "enum": [
               "HOME",
-              "BUSINESS"
+              "WORK"
             ],
-            "description": "The type of address transmitted in this record (ex. HOME, BUSINESS)"
+            "description": "The type of address transmitted in this record (ex. HOME, WORK)"
           },
           "city": {
             "type": "string",

--- a/retain-spec/openapi.json
+++ b/retain-spec/openapi.json
@@ -705,9 +705,9 @@
             "type": "string",
             "enum": [
               "HOME",
-              "BUSINESS"
+              "WORK"
             ],
-            "description": "The type of address transmitted in this record (ex. HOME, BUSINESS)"
+            "description": "The type of address transmitted in this record (ex. HOME, WORK)"
           },
           "city": {
             "type": "string",


### PR DESCRIPTION
## Problem
Documentation indicates `BUSINESS` is a supported physical address type. `ParseAddressType` uses the email address types, so technically we only support `HOME` and `WORK`.

https://trueaccord.slack.com/archives/C010JBUJK5L/p1687470930569179

<img width="703" alt="image" src="https://github.com/othc/retain-go-services/assets/956113/31405c64-879c-44fd-bea4-3576b6c0fb6e">

## Solution
Fix documentation
